### PR TITLE
fix(github): align scripts manifest path with backup repo

### DIFF
--- a/frontend/src/lib/github/fetch.ts
+++ b/frontend/src/lib/github/fetch.ts
@@ -119,7 +119,7 @@ export async function fetchScriptsManifest(
   token: string,
   repo: string
 ): Promise<string | null> {
-  return fetchRawFile(token, repo, "scripts/scripts-manifest.txt");
+  return fetchRawFile(token, repo, "scripts/manifest.txt");
 }
 
 export async function fetchCommitDetail(


### PR DESCRIPTION
## Summary
- `fetchScriptsManifest` queried `scripts/scripts-manifest.txt`, but the device's `backup.sh` writes `scripts/manifest.txt` and always has — so the dashboard's BackupCoverage panel rendered the Scripts row as "no manifest" even on healthy devices.
- One-line fix: change the queried path to match the on-disk filename in `mikevitelli/uconsole`.

## Test plan
- [ ] After merge, the BackupCoverage Scripts tile transitions from yellow "no manifest" to green with a freshness label
- [ ] ScriptsManifest dashboard panel populates with the script list (43 entries on the canonical device as of 2026-05-09)
- [ ] No other refs to `scripts-manifest.txt` exist in the repo (verified — single-call site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)