### PR TITLE
fix(dev): hardening — cherry-picks + accepted review fixes + audit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,19 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Workflow-level least privilege. CI doesn't need to write to the repo,
+# create issues, or push container images — read-only is enough.
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 22
           cache: npm
@@ -27,7 +32,7 @@ jobs:
           shellcheck frontend/public/install.sh
           shellcheck frontend/public/scripts/uconsole
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
@@ -60,15 +65,15 @@ jobs:
     needs: ci
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build .deb
         run: bash packaging/build-deb.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Extract version from tag
         id: version
@@ -29,7 +29,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 22
           cache: npm
@@ -69,7 +69,7 @@ jobs:
           echo "Built: $DEB ($(du -h "$DEB" | cut -f1))"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           files: dist/uconsole-cloud_*.deb
           generate_release_notes: true

--- a/device/lib/tui/framework.py
+++ b/device/lib/tui/framework.py
@@ -30,7 +30,14 @@ _PKG_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 SCRIPT_DIR = os.environ.get('UCONSOLE_SCRIPTS',
     os.path.join(_PKG_ROOT, 'scripts') if os.path.isdir(os.path.join(_PKG_ROOT, 'scripts'))
     else '/opt/uconsole/scripts')
-CONFIG_FILE = os.path.join(SCRIPT_DIR, ".console-config.json")
+
+# CONFIG_FILE: writable per-user JSON. Lives in $XDG_CONFIG_HOME/uconsole/
+# (default ~/.config/uconsole/). Was previously SCRIPT_DIR/.console-config.json,
+# which is root-owned in /opt/uconsole/scripts/ on a packaged install — every
+# save_config() PermissionError'd silently for end users.
+_XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME') or os.path.join(os.path.expanduser('~'), '.config')
+CONFIG_DIR = os.path.join(_XDG_CONFIG_HOME, 'uconsole')
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'console.json')
 
 # Package version — always read VERSION (updated by /publish). Append '-dev'
 # when running from a non-installed tree so you can tell at a glance whether
@@ -611,6 +618,7 @@ def load_config():
 
 def _save_config_locked(updates):
     """Atomically read-modify-write config with file locking."""
+    os.makedirs(CONFIG_DIR, exist_ok=True)
     fd = os.open(CONFIG_FILE, os.O_RDWR | os.O_CREAT, 0o644)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
@@ -2263,13 +2271,38 @@ def main(scr):
     return None
 
 
+def _migrate_legacy_config():
+    """Copy older config files into CONFIG_FILE on first run.
+
+    Two legacy locations, both inside SCRIPT_DIR (root-owned post-deploy):
+      - .console-theme.json   (0.1.x — theme only)
+      - .console-config.json  (0.2.x — full config)
+
+    Copy rather than rename, since the old file lives in a root-owned tree
+    on packaged installs and rename would fail. The orphan stays put; it's
+    no longer read once CONFIG_FILE exists.
+    """
+    if os.path.isfile(CONFIG_FILE):
+        return
+    for legacy in (
+        os.path.join(SCRIPT_DIR, ".console-config.json"),
+        os.path.join(SCRIPT_DIR, ".console-theme.json"),
+    ):
+        if not os.path.isfile(legacy):
+            continue
+        try:
+            os.makedirs(CONFIG_DIR, exist_ok=True)
+            with open(legacy) as src, open(CONFIG_FILE, "w") as dst:
+                dst.write(src.read())
+            return
+        except OSError:
+            continue
+
+
 def entry(scr):
     """Entry point that switches between list and tile views."""
     _init_workspace()
-    # Migrate old config
-    old_config = os.path.join(SCRIPT_DIR, ".console-theme.json")
-    if os.path.isfile(old_config) and not os.path.isfile(CONFIG_FILE):
-        os.rename(old_config, CONFIG_FILE)
+    _migrate_legacy_config()
 
     while True:
         mode = load_view_mode()

--- a/device/scripts/system/etc/sudoers.d/010_pi-nopasswd
+++ b/device/scripts/system/etc/sudoers.d/010_pi-nopasswd
@@ -1,1 +1,0 @@
-mikevitelli ALL=(ALL) NOPASSWD: ALL

--- a/device/scripts/system/etc/sudoers.d/hwclock
+++ b/device/scripts/system/etc/sudoers.d/hwclock
@@ -1,1 +1,0 @@
-mikevitelli ALL=(ALL) NOPASSWD: /sbin/hwclock

--- a/device/scripts/system/restore.sh
+++ b/device/scripts/system/restore.sh
@@ -178,7 +178,6 @@ if confirm "  Apply system configs (boot, udev, apt sources)?"; then
 
     # -- timezone --
     if [ -f "$REPO_DIR/system/etc/timezone" ]; then
-        local tz
         tz=$(cat "$REPO_DIR/system/etc/timezone")
         sudo timedatectl set-timezone "$tz" 2>/dev/null
         echo "  -> timezone: $tz"
@@ -197,7 +196,7 @@ if confirm "  Apply system configs (boot, udev, apt sources)?"; then
 
     # -- WiFi connections --
     if [ -d "$REPO_DIR/system/wifi" ] && [ "$(ls -A "$REPO_DIR/system/wifi" 2>/dev/null)" ]; then
-        local wifi_count=0
+        wifi_count=0
         for conn in "$REPO_DIR/system/wifi"/*.nmconnection; do
             [ -f "$conn" ] || continue
             sudo cp "$conn" /etc/NetworkManager/system-connections/

--- a/device/webdash/app.py
+++ b/device/webdash/app.py
@@ -231,8 +231,9 @@ def api_set_password():
         return redirect('/login')
     pw = request.form.get('password', '')
     confirm = request.form.get('confirm', '')
-    if len(pw) < 4:
-        return render_template('set_password.html', error='Password must be at least 4 characters'), 400
+    if len(pw) < _PASSWORD_MIN_LEN:
+        return render_template('set_password.html',
+            error=f'Password must be at least {_PASSWORD_MIN_LEN} characters'), 400
     if pw != confirm:
         return render_template('set_password.html', error='Passwords do not match'), 400
     h = _hash_password(pw)
@@ -253,8 +254,8 @@ def api_change_password():
         return jsonify({'error': 'Not authenticated'}), 401
     pw = request.form.get('password', '')
     confirm = request.form.get('confirm', '')
-    if len(pw) < 4:
-        return jsonify({'error': 'Password must be at least 4 characters'}), 400
+    if len(pw) < _PASSWORD_MIN_LEN:
+        return jsonify({'error': f'Password must be at least {_PASSWORD_MIN_LEN} characters'}), 400
     if pw != confirm:
         return jsonify({'error': 'Passwords do not match'}), 400
     h = _hash_password(pw)
@@ -278,6 +279,26 @@ def logout():
 _rate_buckets = {}  # ip -> (count, window_start)
 _RATE_LIMIT = 30
 _RATE_WINDOW = 60
+
+
+_TRUSTED_PROXY_IPS = frozenset(('127.0.0.1', '::1'))
+
+
+def _client_ip():
+    """Return the trusted client IP.
+
+    nginx terminates TLS on 443 and proxies to Flask on 127.0.0.1:8080,
+    setting X-Real-IP. Only honor X-Real-IP when the direct hop is
+    loopback — otherwise an attacker hitting Flask directly (or via a
+    misconfigured proxy) could spoof the header to claim a private IP
+    and unlock _LOCAL_ONLY_PATHS.
+    """
+    direct = request.remote_addr or ''
+    if direct in _TRUSTED_PROXY_IPS:
+        forwarded = request.headers.get('X-Real-IP')
+        if forwarded:
+            return forwarded.strip()
+    return direct
 
 
 def _is_local_ip(ip):
@@ -308,12 +329,40 @@ def _check_rate_limit(ip):
     return True
 
 
+# Auth-path rate limit — separate bucket and tighter ceiling than the
+# generic local-only one, since /login is the brute-force surface.
+_auth_buckets = {}
+_AUTH_RATE_LIMIT = 10
+_AUTH_RATE_WINDOW = 60
+
+
+def _check_auth_rate_limit(ip):
+    """Returns True if auth request is allowed, False if rate limited."""
+    now = time.time()
+    count, start = _auth_buckets.get(ip, (0, now))
+    if now - start > _AUTH_RATE_WINDOW:
+        _auth_buckets[ip] = (1, now)
+        return True
+    if count >= _AUTH_RATE_LIMIT:
+        return False
+    _auth_buckets[ip] = (count + 1, start)
+    return True
+
+
 _PUBLIC_PATHS = frozenset((
     '/login', '/setup-password', '/api/set-password',
     '/favicon.png', '/apple-touch-icon.png',
     '/apple-touch-icon-precomposed.png', '/uconsole.crt',
     '/uConsole.gif', '/manifest.json', '/sw.js',
 ))
+# Subset of _PUBLIC_PATHS that POST credentials. Rate-limited per IP to
+# slow brute-force from the LAN.
+_AUTH_PATHS = frozenset((
+    '/login', '/api/set-password',
+))
+# Minimum password length when first set or rotated. The earlier 4-char
+# floor was indefensible on a LAN-reachable login.
+_PASSWORD_MIN_LEN = 10
 _LOCAL_ONLY_PATHS = frozenset((
     '/api/public/stats',
     '/api/esp32/push', '/api/esp32',
@@ -326,10 +375,15 @@ _LOCAL_ONLY_PATHS = frozenset((
 
 @app.before_request
 def require_auth():
+    # Auth-path rate-limit applies even though these are publicly reachable —
+    # they're the brute-force surface. Check before the public-paths bypass.
+    if request.path in _AUTH_PATHS and request.method == 'POST':
+        if not _check_auth_rate_limit(_client_ip()):
+            return jsonify({'error': 'Too many attempts. Please wait a minute.'}), 429
     if request.path in _PUBLIC_PATHS:
         return
     if request.path in _LOCAL_ONLY_PATHS:
-        client_ip = request.headers.get('X-Real-IP', request.remote_addr)
+        client_ip = _client_ip()
         if not _is_local_ip(client_ip):
             return jsonify({'error': 'Forbidden'}), 403
         if not _check_rate_limit(client_ip):
@@ -864,7 +918,7 @@ def api_stats():
 @app.route('/api/public/stats')
 def api_public_stats():
     """Public system stats endpoint — no auth, rate limited, local IPs only."""
-    client_ip = request.headers.get('X-Real-IP', request.remote_addr)
+    client_ip = _client_ip()
     if not _is_local_ip(client_ip):
         return jsonify({'error': 'Forbidden'}), 403
     if not _check_rate_limit(client_ip):
@@ -1422,9 +1476,14 @@ def api_run(script):
         return jsonify({'error': 'Script timed out', 'output': '', 'returncode': -1})
 
 
-@app.route('/api/stream/<script>', methods=['GET'])
+@app.route('/api/stream/<script>', methods=['POST'])
 def api_stream(script):
-    """Stream script output line-by-line via Server-Sent Events."""
+    """Stream script output line-by-line via Server-Sent Events.
+
+    POST-only so that running a script is not reachable via a state-changing
+    HTTP GET (defense in depth on top of the SameSite=Lax session cookie).
+    The JS client uses fetch() with a streaming response reader.
+    """
     if script not in ALLOWED_SCRIPTS:
         return jsonify({'error': 'Unknown script'}), 404
 

--- a/device/webdash/static/js/dashboard.js
+++ b/device/webdash/static/js/dashboard.js
@@ -985,29 +985,43 @@ async function run(name) {
   _showRaw = false;
 
   try {
-    var es = new EventSource('/api/stream/' + name);
-
-    es.onmessage = function(e) {
-      _rawOutput += e.data + '\n';
-      pre.textContent += e.data + '\n';
-      pre.scrollTop = pre.scrollHeight;
-    };
-
-    await new Promise(function(resolve, reject) {
-      es.addEventListener('done', function(e) {
-        es.close();
-        try {
-          var d = JSON.parse(e.data);
-          _rawRc = d.returncode;
-          _rawError = d.error || '';
-        } catch(ex) {}
-        resolve();
-      });
-      es.onerror = function() {
-        es.close();
-        reject(new Error('Stream connection lost'));
-      };
-    });
+    /* POST + fetch streaming — /api/stream is POST-only so EventSource (GET)
+       can't be used. Parse SSE frames manually from the response body. */
+    var resp = await fetch('/api/stream/' + encodeURIComponent(name), { method: 'POST' });
+    if (!resp.ok || !resp.body) throw new Error('Stream open failed: HTTP ' + resp.status);
+    var reader = resp.body.getReader();
+    var decoder = new TextDecoder();
+    var buffer = '';
+    var streamDone = false;
+    while (!streamDone) {
+      var chunk = await reader.read();
+      if (chunk.done) break;
+      buffer += decoder.decode(chunk.value, { stream: true });
+      var idx;
+      while ((idx = buffer.indexOf('\n\n')) >= 0) {
+        var frame = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        var eventName = 'message';
+        var dataLines = [];
+        frame.split('\n').forEach(function(line) {
+          if (line.indexOf('event: ') === 0) eventName = line.slice(7);
+          else if (line.indexOf('data: ') === 0) dataLines.push(line.slice(6));
+        });
+        var data = dataLines.join('\n');
+        if (eventName === 'done') {
+          try {
+            var d = JSON.parse(data);
+            _rawRc = d.returncode;
+            _rawError = d.error || '';
+          } catch (ex) {}
+          streamDone = true;
+        } else if (eventName === 'message' && dataLines.length) {
+          _rawOutput += data + '\n';
+          pre.textContent += data + '\n';
+          pre.scrollTop = pre.scrollHeight;
+        }
+      }
+    }
 
     var elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
 

--- a/device/webdash/static/js/dashboard.js
+++ b/device/webdash/static/js/dashboard.js
@@ -1521,26 +1521,83 @@ function openWifiPicker() {
   document.body.appendChild(modal);
   modal.addEventListener('click', function(e) { if (e.target === modal) closeWifiPicker(); });
   fetch('/api/wifi/scan').then(function(r){return r.json()}).then(function(data) {
-    if (data.error) { document.getElementById('wifi-list').innerHTML = '<div style="padding:1rem;color:var(--red);">' + esc(data.error) + '</div>'; return; }
-    var html = '';
+    var listEl = document.getElementById('wifi-list');
+    if (data.error) {
+      listEl.textContent = '';
+      var err = document.createElement('div');
+      err.style.cssText = 'padding:1rem;color:var(--red);';
+      err.textContent = data.error;
+      listEl.appendChild(err);
+      return;
+    }
+    listEl.textContent = '';
+    if (!data.networks || !data.networks.length) {
+      var none = document.createElement('div');
+      none.style.cssText = 'padding:1rem;color:var(--dim);';
+      none.textContent = 'No networks found';
+      listEl.appendChild(none);
+      return;
+    }
     data.networks.forEach(function(n) {
+      // Hostile APs can include arbitrary text in SSID/security fields.
+      // Build the row via DOM so user-controlled values can never escape
+      // an attribute or insert event handlers.
       var bars = n.signal > 75 ? 4 : n.signal > 50 ? 3 : n.signal > 25 ? 2 : 1;
-      var barStr = '\u2582'.repeat(bars) + '<span style="color:var(--dim)">' + '\u2582'.repeat(4-bars) + '</span>';
       var lock = n.security !== 'Open' ? ' \uD83D\uDD12' : '';
-      var active = n.active ? ' style="border:1px solid var(--green);background:var(--green-glow);"' : ' style="border:1px solid var(--border);"';
-      var badge = n.active ? '<span style="color:var(--green);font-size:0.75rem;margin-left:0.5rem;">Connected</span>' : '';
-      html += '<div class="wifi-item" onclick="selectWifi(this,\'' + n.ssid.replace(/'/g, "\\'") + '\',\'' + n.security + '\')"' + active
-        + ' data-ssid="' + n.ssid.replace(/"/g, '&quot;') + '"'
-        + ' style="padding:0.7rem 0.9rem;border-radius:10px;margin-bottom:0.4rem;cursor:pointer;' + (n.active ? 'border:1px solid var(--green);background:var(--green-glow);' : 'border:1px solid var(--border);') + '">'
-        + '<div style="display:flex;justify-content:space-between;align-items:center;">'
-        + '<span style="color:var(--bright);">' + esc(n.ssid) + lock + badge + '</span>'
-        + '<span style="font-size:0.9rem;">' + barStr + ' <span style="color:var(--dim);font-size:0.75rem;">' + n.signal + '%</span></span>'
-        + '</div></div>';
+
+      var row = document.createElement('div');
+      row.className = 'wifi-item';
+      row.style.cssText = 'padding:0.7rem 0.9rem;border-radius:10px;margin-bottom:0.4rem;cursor:pointer;'
+        + (n.active ? 'border:1px solid var(--green);background:var(--green-glow);' : 'border:1px solid var(--border);');
+      row.dataset.ssid = String(n.ssid || '');
+
+      var inner = document.createElement('div');
+      inner.style.cssText = 'display:flex;justify-content:space-between;align-items:center;';
+
+      var leftSpan = document.createElement('span');
+      leftSpan.style.cssText = 'color:var(--bright);';
+      leftSpan.textContent = String(n.ssid || '') + lock;
+      if (n.active) {
+        var badge = document.createElement('span');
+        badge.style.cssText = 'color:var(--green);font-size:0.75rem;margin-left:0.5rem;';
+        badge.textContent = 'Connected';
+        leftSpan.appendChild(badge);
+      }
+
+      var rightSpan = document.createElement('span');
+      rightSpan.style.cssText = 'font-size:0.9rem;';
+      // Bar chars are static. Render with two spans so the dim trailing
+      // segment doesn't need string concat with style attributes.
+      var barLit = document.createElement('span');
+      barLit.textContent = '\u2582'.repeat(bars);
+      var barDim = document.createElement('span');
+      barDim.style.cssText = 'color:var(--dim);';
+      barDim.textContent = '\u2582'.repeat(4 - bars);
+      var pctSpan = document.createElement('span');
+      pctSpan.style.cssText = 'color:var(--dim);font-size:0.75rem;';
+      pctSpan.textContent = ' ' + Number(n.signal || 0) + '%';
+      rightSpan.appendChild(barLit);
+      rightSpan.appendChild(barDim);
+      rightSpan.appendChild(pctSpan);
+
+      inner.appendChild(leftSpan);
+      inner.appendChild(rightSpan);
+      row.appendChild(inner);
+
+      // Capture ssid/security in the closure \u2014 never interpolated.
+      row.addEventListener('click', function() {
+        selectWifi(row, String(n.ssid || ''), String(n.security || ''));
+      });
+
+      listEl.appendChild(row);
     });
-    if (!html) html = '<div style="padding:1rem;color:var(--dim);">No networks found</div>';
-    document.getElementById('wifi-list').innerHTML = html;
   }).catch(function(e) {
-    document.getElementById('wifi-list').innerHTML = '<div style="padding:1rem;color:var(--red);">Scan failed: ' + esc(String(e)) + '</div>';
+    var listEl = document.getElementById('wifi-list');
+    listEl.textContent = '';
+    var err = document.createElement('div');
+    err.style.cssText = 'padding:1rem;color:var(--red);';
+    err.textContent = 'Scan failed: ' + String(e);
+    listEl.appendChild(err);
   });
 }
 
@@ -1551,10 +1608,23 @@ function selectWifi(el, ssid, security) {
   var form = document.createElement('div');
   form.className = 'wifi-password-form';
   form.style.cssText = 'margin-top:0.5rem;display:flex;gap:0.4rem;';
-  form.innerHTML = '<input type="password" placeholder="Password" autocomplete="off" style="flex:1;padding:0.5rem 0.7rem;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--bright);font-size:0.9rem;outline:none;">'
-    + '<button onclick="connectWifi(\'' + ssid.replace(/'/g, "\\'") + '\', this.parentNode.querySelector(\'input\').value)" style="padding:0.5rem 1rem;background:var(--accent);color:var(--bg);border:none;border-radius:8px;font-weight:600;cursor:pointer;">Join</button>';
+
+  var input = document.createElement('input');
+  input.type = 'password';
+  input.placeholder = 'Password';
+  input.autocomplete = 'off';
+  input.style.cssText = 'flex:1;padding:0.5rem 0.7rem;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--bright);font-size:0.9rem;outline:none;';
+
+  var join = document.createElement('button');
+  join.type = 'button';
+  join.textContent = 'Join';
+  join.style.cssText = 'padding:0.5rem 1rem;background:var(--accent);color:var(--bg);border:none;border-radius:8px;font-weight:600;cursor:pointer;';
+  join.addEventListener('click', function() { connectWifi(ssid, input.value); });
+
+  form.appendChild(input);
+  form.appendChild(join);
   el.appendChild(form);
-  form.querySelector('input').focus();
+  input.focus();
 }
 
 function connectWifi(ssid, password) {

--- a/device/webdash/templates/js/dashboard.js
+++ b/device/webdash/templates/js/dashboard.js
@@ -985,29 +985,43 @@ async function run(name) {
   _showRaw = false;
 
   try {
-    var es = new EventSource('/api/stream/' + name);
-
-    es.onmessage = function(e) {
-      _rawOutput += e.data + '\n';
-      pre.textContent += e.data + '\n';
-      pre.scrollTop = pre.scrollHeight;
-    };
-
-    await new Promise(function(resolve, reject) {
-      es.addEventListener('done', function(e) {
-        es.close();
-        try {
-          var d = JSON.parse(e.data);
-          _rawRc = d.returncode;
-          _rawError = d.error || '';
-        } catch(ex) {}
-        resolve();
-      });
-      es.onerror = function() {
-        es.close();
-        reject(new Error('Stream connection lost'));
-      };
-    });
+    /* POST + fetch streaming — /api/stream is POST-only so EventSource (GET)
+       can't be used. Parse SSE frames manually from the response body. */
+    var resp = await fetch('/api/stream/' + encodeURIComponent(name), { method: 'POST' });
+    if (!resp.ok || !resp.body) throw new Error('Stream open failed: HTTP ' + resp.status);
+    var reader = resp.body.getReader();
+    var decoder = new TextDecoder();
+    var buffer = '';
+    var streamDone = false;
+    while (!streamDone) {
+      var chunk = await reader.read();
+      if (chunk.done) break;
+      buffer += decoder.decode(chunk.value, { stream: true });
+      var idx;
+      while ((idx = buffer.indexOf('\n\n')) >= 0) {
+        var frame = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        var eventName = 'message';
+        var dataLines = [];
+        frame.split('\n').forEach(function(line) {
+          if (line.indexOf('event: ') === 0) eventName = line.slice(7);
+          else if (line.indexOf('data: ') === 0) dataLines.push(line.slice(6));
+        });
+        var data = dataLines.join('\n');
+        if (eventName === 'done') {
+          try {
+            var d = JSON.parse(data);
+            _rawRc = d.returncode;
+            _rawError = d.error || '';
+          } catch (ex) {}
+          streamDone = true;
+        } else if (eventName === 'message' && dataLines.length) {
+          _rawOutput += data + '\n';
+          pre.textContent += data + '\n';
+          pre.scrollTop = pre.scrollHeight;
+        }
+      }
+    }
 
     var elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
 

--- a/device/webdash/templates/js/dashboard.js
+++ b/device/webdash/templates/js/dashboard.js
@@ -1521,26 +1521,83 @@ function openWifiPicker() {
   document.body.appendChild(modal);
   modal.addEventListener('click', function(e) { if (e.target === modal) closeWifiPicker(); });
   fetch('/api/wifi/scan').then(function(r){return r.json()}).then(function(data) {
-    if (data.error) { document.getElementById('wifi-list').innerHTML = '<div style="padding:1rem;color:var(--red);">' + esc(data.error) + '</div>'; return; }
-    var html = '';
+    var listEl = document.getElementById('wifi-list');
+    if (data.error) {
+      listEl.textContent = '';
+      var err = document.createElement('div');
+      err.style.cssText = 'padding:1rem;color:var(--red);';
+      err.textContent = data.error;
+      listEl.appendChild(err);
+      return;
+    }
+    listEl.textContent = '';
+    if (!data.networks || !data.networks.length) {
+      var none = document.createElement('div');
+      none.style.cssText = 'padding:1rem;color:var(--dim);';
+      none.textContent = 'No networks found';
+      listEl.appendChild(none);
+      return;
+    }
     data.networks.forEach(function(n) {
+      // Hostile APs can include arbitrary text in SSID/security fields.
+      // Build the row via DOM so user-controlled values can never escape
+      // an attribute or insert event handlers.
       var bars = n.signal > 75 ? 4 : n.signal > 50 ? 3 : n.signal > 25 ? 2 : 1;
-      var barStr = '\u2582'.repeat(bars) + '<span style="color:var(--dim)">' + '\u2582'.repeat(4-bars) + '</span>';
       var lock = n.security !== 'Open' ? ' \uD83D\uDD12' : '';
-      var active = n.active ? ' style="border:1px solid var(--green);background:var(--green-glow);"' : ' style="border:1px solid var(--border);"';
-      var badge = n.active ? '<span style="color:var(--green);font-size:0.75rem;margin-left:0.5rem;">Connected</span>' : '';
-      html += '<div class="wifi-item" onclick="selectWifi(this,\'' + n.ssid.replace(/'/g, "\\'") + '\',\'' + n.security + '\')"' + active
-        + ' data-ssid="' + n.ssid.replace(/"/g, '&quot;') + '"'
-        + ' style="padding:0.7rem 0.9rem;border-radius:10px;margin-bottom:0.4rem;cursor:pointer;' + (n.active ? 'border:1px solid var(--green);background:var(--green-glow);' : 'border:1px solid var(--border);') + '">'
-        + '<div style="display:flex;justify-content:space-between;align-items:center;">'
-        + '<span style="color:var(--bright);">' + esc(n.ssid) + lock + badge + '</span>'
-        + '<span style="font-size:0.9rem;">' + barStr + ' <span style="color:var(--dim);font-size:0.75rem;">' + n.signal + '%</span></span>'
-        + '</div></div>';
+
+      var row = document.createElement('div');
+      row.className = 'wifi-item';
+      row.style.cssText = 'padding:0.7rem 0.9rem;border-radius:10px;margin-bottom:0.4rem;cursor:pointer;'
+        + (n.active ? 'border:1px solid var(--green);background:var(--green-glow);' : 'border:1px solid var(--border);');
+      row.dataset.ssid = String(n.ssid || '');
+
+      var inner = document.createElement('div');
+      inner.style.cssText = 'display:flex;justify-content:space-between;align-items:center;';
+
+      var leftSpan = document.createElement('span');
+      leftSpan.style.cssText = 'color:var(--bright);';
+      leftSpan.textContent = String(n.ssid || '') + lock;
+      if (n.active) {
+        var badge = document.createElement('span');
+        badge.style.cssText = 'color:var(--green);font-size:0.75rem;margin-left:0.5rem;';
+        badge.textContent = 'Connected';
+        leftSpan.appendChild(badge);
+      }
+
+      var rightSpan = document.createElement('span');
+      rightSpan.style.cssText = 'font-size:0.9rem;';
+      // Bar chars are static. Render with two spans so the dim trailing
+      // segment doesn't need string concat with style attributes.
+      var barLit = document.createElement('span');
+      barLit.textContent = '\u2582'.repeat(bars);
+      var barDim = document.createElement('span');
+      barDim.style.cssText = 'color:var(--dim);';
+      barDim.textContent = '\u2582'.repeat(4 - bars);
+      var pctSpan = document.createElement('span');
+      pctSpan.style.cssText = 'color:var(--dim);font-size:0.75rem;';
+      pctSpan.textContent = ' ' + Number(n.signal || 0) + '%';
+      rightSpan.appendChild(barLit);
+      rightSpan.appendChild(barDim);
+      rightSpan.appendChild(pctSpan);
+
+      inner.appendChild(leftSpan);
+      inner.appendChild(rightSpan);
+      row.appendChild(inner);
+
+      // Capture ssid/security in the closure \u2014 never interpolated.
+      row.addEventListener('click', function() {
+        selectWifi(row, String(n.ssid || ''), String(n.security || ''));
+      });
+
+      listEl.appendChild(row);
     });
-    if (!html) html = '<div style="padding:1rem;color:var(--dim);">No networks found</div>';
-    document.getElementById('wifi-list').innerHTML = html;
   }).catch(function(e) {
-    document.getElementById('wifi-list').innerHTML = '<div style="padding:1rem;color:var(--red);">Scan failed: ' + esc(String(e)) + '</div>';
+    var listEl = document.getElementById('wifi-list');
+    listEl.textContent = '';
+    var err = document.createElement('div');
+    err.style.cssText = 'padding:1rem;color:var(--red);';
+    err.textContent = 'Scan failed: ' + String(e);
+    listEl.appendChild(err);
   });
 }
 
@@ -1551,10 +1608,23 @@ function selectWifi(el, ssid, security) {
   var form = document.createElement('div');
   form.className = 'wifi-password-form';
   form.style.cssText = 'margin-top:0.5rem;display:flex;gap:0.4rem;';
-  form.innerHTML = '<input type="password" placeholder="Password" autocomplete="off" style="flex:1;padding:0.5rem 0.7rem;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--bright);font-size:0.9rem;outline:none;">'
-    + '<button onclick="connectWifi(\'' + ssid.replace(/'/g, "\\'") + '\', this.parentNode.querySelector(\'input\').value)" style="padding:0.5rem 1rem;background:var(--accent);color:var(--bg);border:none;border-radius:8px;font-weight:600;cursor:pointer;">Join</button>';
+
+  var input = document.createElement('input');
+  input.type = 'password';
+  input.placeholder = 'Password';
+  input.autocomplete = 'off';
+  input.style.cssText = 'flex:1;padding:0.5rem 0.7rem;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--bright);font-size:0.9rem;outline:none;';
+
+  var join = document.createElement('button');
+  join.type = 'button';
+  join.textContent = 'Join';
+  join.style.cssText = 'padding:0.5rem 1rem;background:var(--accent);color:var(--bg);border:none;border-radius:8px;font-weight:600;cursor:pointer;';
+  join.addEventListener('click', function() { connectWifi(ssid, input.value); });
+
+  form.appendChild(input);
+  form.appendChild(join);
   el.appendChild(form);
-  form.querySelector('input').focus();
+  input.focus();
 }
 
 function connectWifi(ssid, password) {

--- a/device/webdash/templates/set_password.html
+++ b/device/webdash/templates/set_password.html
@@ -41,8 +41,8 @@ body {
   <h1>Welcome to uConsole</h1>
   <p class="sub">Set a password to secure your dashboard.</p>
   {% if error %}<p class="error">{{ error }}</p>{% endif %}
-  <input type="password" name="password" placeholder="New password" required minlength="4">
-  <input type="password" name="confirm" placeholder="Confirm password" required minlength="4">
+  <input type="password" name="password" placeholder="New password" required minlength="10">
+  <input type="password" name="confirm" placeholder="Confirm password" required minlength="10">
   <button type="submit">Set Password</button>
 </form>
 </body>

--- a/frontend/src/app/api/device/push/route.ts
+++ b/frontend/src/app/api/device/push/route.ts
@@ -1,8 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
 import { validateDeviceToken } from "@/lib/deviceToken";
 import { redis } from "@/lib/redis";
+import { checkRateLimit } from "@/lib/rateLimit";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// RFC 1123-ish hostname charset. Permissive enough for typical device
+// hostnames (kebab and underscore allowed) without being a free-for-all.
+const HOSTNAME_RE = /^[a-zA-Z0-9._-]+$/;
+
+// 32 KB is a generous ceiling — real push-status.sh payloads are
+// ~1-2 KB. Keeps a leaked token from bloating Redis with arbitrary JSON.
+const MAX_BODY_BYTES = 32 * 1024;
+// 30 pushes/min lets the default 60s interval breathe (the device timer
+// drifts slightly) while capping abuse to ~one write every 2s.
+const PUSH_RATE_LIMIT = 30;
+const PUSH_RATE_WINDOW = 60;
+
+function isValidTelemetry(
+  body: unknown
+): body is { hostname: string; collectedAt: string } {
+  if (!body || typeof body !== "object") return false;
+  const b = body as Record<string, unknown>;
+  if (typeof b.hostname !== "string") return false;
+  if (b.hostname.length === 0 || b.hostname.length > 64) return false;
+  if (!HOSTNAME_RE.test(b.hostname)) return false;
+  if (typeof b.collectedAt !== "string") return false;
+  if (b.collectedAt.length > 64) return false;
+  if (Number.isNaN(Date.parse(b.collectedAt))) return false;
+  return true;
+}
 
 export async function POST(req: NextRequest) {
   // Extract Bearer token
@@ -31,8 +57,33 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // Rate-limit per token. A leaked token is an inevitability we can't
+  // detect; capping write rate keeps it from being weaponized into a
+  // Redis bloat / DoS / log-spam channel.
+  const rl = await checkRateLimit(
+    `device-push:${token}`,
+    PUSH_RATE_LIMIT,
+    PUSH_RATE_WINDOW
+  );
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rl.retryAfterSeconds ?? PUSH_RATE_WINDOW) },
+      }
+    );
+  }
+
+  // Pre-parse size cap via Content-Length. Some clients omit it; the
+  // post-parse check below is the real gate.
+  const declaredLen = parseInt(req.headers.get("content-length") || "0", 10);
+  if (declaredLen > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
+
   // Parse and validate payload
-  let body: Record<string, unknown>;
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
@@ -42,23 +93,31 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  if (!body.hostname || !body.collectedAt) {
+  // Real size check on the serialized body — Content-Length can lie.
+  const serialized = JSON.stringify(body ?? null);
+  if (serialized.length > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  if (!isValidTelemetry(body)) {
     return NextResponse.json(
-      { error: "Missing required fields: hostname, collectedAt" },
+      { error: "Invalid telemetry: hostname and collectedAt required" },
       { status: 400 }
     );
   }
+
+  const out = body as Record<string, unknown>;
 
   // Capture the device's public IP (after NAT) for same-network detection
   const forwarded = req.headers.get("x-forwarded-for");
   const devicePublicIp = forwarded?.split(",")[0].trim() || null;
   if (devicePublicIp) {
-    (body as Record<string, unknown>)._publicIp = devicePublicIp;
+    out._publicIp = devicePublicIp;
   }
 
   // Write to Redis — no TTL, persists until next push.
   // "Online" status is derived from collectedAt age.
-  await redis.set(`device:${device.repo}:status`, body);
+  await redis.set(`device:${device.repo}:status`, out);
 
   return NextResponse.json({ ok: true });
 }

--- a/frontend/src/components/dashboard/DeviceOnline.tsx
+++ b/frontend/src/components/dashboard/DeviceOnline.tsx
@@ -4,6 +4,7 @@ import { StatusGrid } from "@/components/viz/StatusGrid";
 import { batteryColor, tempColor, stalenessColor } from "@/lib/device-colors";
 import { formatAge } from "@/lib/deviceStatus";
 import type { DeviceStatusPayload } from "@/lib/deviceStatus";
+import { buildLocalDashboardUrl } from "@/lib/network";
 
 interface DeviceOnlineProps {
   status: DeviceStatusPayload;
@@ -20,6 +21,9 @@ export function DeviceOnline({
 }: DeviceOnlineProps) {
   const { battery, cpu, memory, disk, wifi, aio, screen } = status;
   const memUsedPct = Math.round((memory.usedMB / memory.totalMB) * 100);
+  // Device-pushed wifi.ip is untrusted — only build the link when it's
+  // a literal IP. See buildLocalDashboardUrl for the threat model.
+  const localShellUrl = buildLocalDashboardUrl(wifi.ip);
 
   return (
     <section className="bg-card border border-border rounded-xl p-4">
@@ -200,12 +204,12 @@ export function DeviceOnline({
       </div>
 
       {/* Local Shell Hub — subtle link when not on same network (banner handles it otherwise) */}
-      {!isSameNetwork && status.webdash?.running && wifi.ip && wifi.ip !== "none" && (
+      {!isSameNetwork && status.webdash?.running && localShellUrl && (
         <div className="mt-3 flex items-center gap-2 bg-background border border-border rounded-lg px-3 py-2">
           <span className="w-2 h-2 rounded-full bg-[var(--green)] shrink-0" />
           <div className="flex-1 min-w-0">
             <a
-              href={`https://${wifi.ip}`}
+              href={localShellUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-xs font-medium text-bright hover:underline"

--- a/frontend/src/components/dashboard/LocalModeShell.tsx
+++ b/frontend/src/components/dashboard/LocalModeShell.tsx
@@ -1,6 +1,7 @@
 import { DeviceStatus } from "@/components/dashboard/DeviceStatus";
 import { QuickActions } from "@/components/dashboard/QuickActions";
 import type { DeviceStatusPayload, WifiFallbackStatus } from "@/lib/deviceStatus";
+import { buildLocalDashboardUrl } from "@/lib/network";
 
 interface DeviceStatusContent {
   heading?: string;
@@ -34,10 +35,10 @@ export function LocalModeShell({
 }: LocalModeShellProps) {
   // Support both new (deviceLocalIp) and legacy (deviceIp) prop names
   const deviceLocalIp = deviceLocalIpProp ?? deviceIp ?? null;
-  const webdashUrl =
-    deviceLocalIp && deviceLocalIp !== "none"
-      ? `https://${deviceLocalIp}`
-      : null;
+  // Only build the link when the value is a literal IP. Device-pushed
+  // values are not trusted — a compromised token could push a hostname
+  // (phishing) or characters that misparse the URL.
+  const webdashUrl = buildLocalDashboardUrl(deviceLocalIp);
 
   return (
     <>
@@ -86,7 +87,7 @@ export function LocalModeShell({
           </p>
 
           {/* Quick links */}
-          <QuickActions deviceLocalIp={deviceLocalIp!} />
+          <QuickActions baseUrl={webdashUrl} />
         </section>
       )}
 

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -1,5 +1,6 @@
 interface QuickActionsProps {
-  deviceLocalIp: string;
+  /** Pre-validated `https://<ip>` base URL — caller must use buildLocalDashboardUrl. */
+  baseUrl: string;
 }
 
 const QUICK_LINKS = [
@@ -12,10 +13,11 @@ const QUICK_LINKS = [
 /**
  * Quick-link buttons to specific webdash pages on the local device.
  * Pure <a> tags — no fetch, no client-side state. Opens in new tab.
+ *
+ * Takes a pre-validated base URL rather than the raw IP so callers
+ * can't accidentally feed device-pushed values straight into href.
  */
-export function QuickActions({ deviceLocalIp }: QuickActionsProps) {
-  const base = `https://${deviceLocalIp}`;
-
+export function QuickActions({ baseUrl }: QuickActionsProps) {
   return (
     <div>
       <p className="text-[11px] text-dim font-medium uppercase tracking-wider mb-1.5">
@@ -25,7 +27,7 @@ export function QuickActions({ deviceLocalIp }: QuickActionsProps) {
         {QUICK_LINKS.map((link) => (
           <a
             key={link.label}
-            href={`${base}/${link.hash}`}
+            href={`${baseUrl}/${link.hash}`}
             target="_blank"
             rel="noopener noreferrer"
             className="text-xs font-medium px-2.5 py-1.5 rounded-md border border-border bg-background text-bright hover:border-[var(--accent)] transition-colors"

--- a/frontend/src/lib/network.ts
+++ b/frontend/src/lib/network.ts
@@ -14,3 +14,41 @@ export function checkSameNetwork(
   if (!userPublicIp || !devicePublicIp) return false;
   return userPublicIp === devicePublicIp;
 }
+
+/**
+ * Validate a string as a literal IPv4 or IPv6 address.
+ *
+ * The cloud dashboard interpolates the device-reported `wifi.ip` into
+ * `https://${ip}` `href` attributes (LocalModeShell, DeviceOnline,
+ * QuickActions). The value is push-supplied by the device — a
+ * compromised device token could push `evil.com` (phishing) or a
+ * fragment containing characters that escape the URL.
+ *
+ * Allowing only literal IP addresses keeps the same-network bridge
+ * working while making the click target unspoofable.
+ */
+const IPV4_RE = /^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$/;
+// Permissive IPv6: hex-and-colons only, between 2 and 39 chars. Browsers
+// parse the canonical form; we only need to gate on character class so
+// nothing weird leaks into the href.
+const IPV6_RE = /^[0-9a-fA-F:]{2,39}$/;
+
+export function isValidIp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  if (!value) return false;
+  if (IPV4_RE.test(value)) return true;
+  if (value.includes(":") && IPV6_RE.test(value)) return true;
+  return false;
+}
+
+/**
+ * Build an `https://<ip>` URL only when the value is a literal IP.
+ * Returns null otherwise — caller should render text without a link.
+ *
+ * IPv6 hosts must be bracketed in URLs.
+ */
+export function buildLocalDashboardUrl(ip: unknown): string | null {
+  if (!isValidIp(ip)) return null;
+  const ipStr = ip as string;
+  return ipStr.includes(":") ? `https://[${ipStr}]` : `https://${ipStr}`;
+}

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -56,13 +56,40 @@ find "${BUILD_DIR}/opt/uconsole/" -name '.console-config.json' -delete 2>/dev/nu
 find "${BUILD_DIR}/opt/uconsole/" -name '*.pyc' -delete 2>/dev/null || true
 
 # Scrub user-specific config snapshots that live in device/scripts/ as a
-# private backup but must NOT ship in the public .deb. The install-test
-# CI job greps /opt/uconsole/ for personal data (mikevitelli, 192.168.1.,
-# etc.) and these directories are where it leaks from.
+# private backup but must NOT ship in the public .deb. These are also
+# .gitignored so they shouldn't be in canonical, but cp -r doesn't care
+# about .gitignore — it copies whatever is on the working-tree disk.
 rm -rf "${BUILD_DIR}/opt/uconsole/scripts/ssh"            # personal SSH keys
 rm -rf "${BUILD_DIR}/opt/uconsole/scripts/system/etc"     # crontab.user, sudoers.d
-rm -rf "${BUILD_DIR}/opt/uconsole/scripts/config"         # systemd-user backups, dconf dumps
+rm -rf "${BUILD_DIR}/opt/uconsole/scripts/system/wifi"    # NetworkManager .nmconnection (PSKs)
+rm -rf "${BUILD_DIR}/opt/uconsole/scripts/config"         # systemd-user, dconf, gh OAuth, etc.
+rm -rf "${BUILD_DIR}/opt/uconsole/scripts/packages"       # apt/pip/etc machine snapshots
 rm -f  "${BUILD_DIR}/opt/uconsole/scripts/.console-config.json"
+
+# Scrub PRIVATE SCRIPTS (single source of truth: packaging/private_scripts.txt).
+# Defense-in-depth layer 1: scrub at build time so an accidental re-introduction
+# in canonical can't leak into the .deb. Layer 2 (post-build assertion below)
+# is the real gate.
+#
+# Set BYPASS_PRIVATE_SCRUB=1 to skip this layer — useful only for testing the
+# layer-2 assertion in isolation. Don't set it in production builds.
+PRIVATE_SCRIPTS_FILE="${REPO_ROOT}/packaging/private_scripts.txt"
+if [ ! -f "$PRIVATE_SCRIPTS_FILE" ]; then
+    echo "ERROR: private_scripts.txt missing — cannot enforce private-script scrub" >&2
+    exit 1
+fi
+if [ "${BYPASS_PRIVATE_SCRUB:-0}" != "1" ]; then
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="$(echo "$line" | tr -d '[:space:]')"
+        [ -z "$line" ] && continue
+        target="${BUILD_DIR}/opt/uconsole/scripts/${line}"
+        if [ -e "$target" ]; then
+            echo "  scrubbed private script: ${line}"
+            rm -f "$target"
+        fi
+    done < "$PRIVATE_SCRIPTS_FILE"
+fi
 
 # ── Cloud-side CLI wrapper (overrides device repo's copy if present) ──
 
@@ -132,11 +159,43 @@ cp "${BUILD_DIR}/opt/uconsole/share/defaults/uconsole-completion.bash" "${BUILD_
 
 # ── Build the .deb ──
 
-dpkg-deb --root-owner-group --build "${BUILD_DIR}" "${REPO_ROOT}/dist/${PKG}_${VERSION}_arm64.deb"
+DEB_PATH="${REPO_ROOT}/dist/${PKG}_${VERSION}_arm64.deb"
+dpkg-deb --root-owner-group --build "${BUILD_DIR}" "${DEB_PATH}"
+
+# ── Post-build assertion: no PRIVATE SCRIPTS in shipped .deb ──
+# Background: 0.2.1 (built 2026-04-15) shipped backup.sh because the script
+# was in canonical at build time. This check catches that class of leak by
+# inspecting the actual .deb payload — not just canonical state.
+echo ""
+echo "── Asserting private-script absence in built .deb ──"
+DEB_CONTENTS="$(dpkg-deb -c "${DEB_PATH}")"
+LEAKED=()
+while IFS= read -r line; do
+    line="${line%%#*}"
+    line="$(echo "$line" | tr -d '[:space:]')"
+    [ -z "$line" ] && continue
+    if echo "${DEB_CONTENTS}" | grep -qE "[[:space:]]\./opt/uconsole/scripts/${line}\$"; then
+        LEAKED+=("${line}")
+    fi
+done < "$PRIVATE_SCRIPTS_FILE"
+
+if [ ${#LEAKED[@]} -gt 0 ]; then
+    echo "" >&2
+    echo "FATAL: built .deb contains private scripts that must NOT ship:" >&2
+    for s in "${LEAKED[@]}"; do echo "  - opt/uconsole/scripts/${s}" >&2; done
+    echo "" >&2
+    echo "These paths are listed in packaging/private_scripts.txt." >&2
+    echo "Either remove them from device/scripts/ (preferred) or remove" >&2
+    echo "them from packaging/private_scripts.txt (only if they're now" >&2
+    echo "intentionally public)." >&2
+    rm -f "${DEB_PATH}"
+    exit 1
+fi
+echo "  ok — no private scripts shipped"
 
 echo ""
 echo "Built: dist/${PKG}_${VERSION}_arm64.deb"
-SIZE=$(du -h "${REPO_ROOT}/dist/${PKG}_${VERSION}_arm64.deb" | cut -f1)
+SIZE=$(du -h "${DEB_PATH}" | cut -f1)
 echo "Size:  ${SIZE}"
 echo ""
 echo "To install on device:"

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -100,6 +100,28 @@ chmod +x "${BUILD_DIR}/opt/uconsole/bin/uconsole"
 mkdir -p "${BUILD_DIR}/opt/uconsole/share/defaults"
 cp "${REPO_ROOT}/packaging/defaults/uconsole.conf.default" "${BUILD_DIR}/opt/uconsole/share/defaults/"
 
+# ── Debian-policy boilerplate: changelog + copyright in /usr/share/doc/PKG/ ──
+# Lintian E:no-changelog and E:no-copyright-file otherwise. Mandatory per
+# Debian Policy 12.7 (changelog) and 12.5 (copyright).
+mkdir -p "${BUILD_DIR}/usr/share/doc/${PKG}"
+
+# Upstream changelog: gzip -n (no name/timestamp) for reproducible builds.
+# Project's CHANGELOG.md is markdown, not strict Debian format — that's
+# acceptable for non-archive-uploaded packages. Lintian may warn about
+# format but won't error.
+gzip -9n -c "${REPO_ROOT}/CHANGELOG.md" > "${BUILD_DIR}/usr/share/doc/${PKG}/changelog.gz"
+chmod 644 "${BUILD_DIR}/usr/share/doc/${PKG}/changelog.gz"
+
+# DEP-5 copyright file. Generated inline from packaging/copyright.template
+# so the LICENSE text and project metadata stay in one source of truth.
+if [ -f "${REPO_ROOT}/packaging/copyright" ]; then
+    cp "${REPO_ROOT}/packaging/copyright" "${BUILD_DIR}/usr/share/doc/${PKG}/copyright"
+    chmod 644 "${BUILD_DIR}/usr/share/doc/${PKG}/copyright"
+else
+    echo "ERROR: packaging/copyright missing — Debian Policy 12.5 mandatory" >&2
+    exit 1
+fi
+
 # Ship uconsole.conf as a dpkg conffile (postinst won't overwrite user edits)
 cp "${REPO_ROOT}/packaging/defaults/uconsole.conf.default" "${BUILD_DIR}/etc/uconsole/uconsole.conf"
 

--- a/packaging/copyright
+++ b/packaging/copyright
@@ -1,0 +1,27 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: uconsole-cloud
+Upstream-Contact: Mike Vitelli <mike@digitalcounsel.xyz>
+Source: https://github.com/mikevitelli/uconsole-cloud
+
+Files: *
+Copyright: 2025-2026 Mike Vitelli
+License: MIT
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -111,6 +111,31 @@ with open(path, 'w') as f:
         # Reload systemd to pick up new unit files (but do NOT enable or start)
         systemctl daemon-reload 2>/dev/null || true
 
+        # ── Security cleanup: remove leaky backup.sh from prior versions ──
+        # Versions 0.1.0 through 0.2.1 shipped /opt/uconsole/scripts/system/
+        # backup.sh which captures WiFi PSKs, sudoers, gh OAuth token, etc.
+        # The script doesn't auto-run (uconsole-backup.timer is not auto-
+        # enabled by this postinst), but ships executable. Devices that
+        # enabled the timer AND had /opt/uconsole as a git repo could
+        # have leaked credentials.
+        #
+        # On upgrade from any leaky version, remove the file. Operator-
+        # installed copies (the maintainer's private backup repo into
+        # /opt/uconsole/scripts/system/) would also be cleaned, but those
+        # belong in ~/pkg/scripts/system/backup.sh anyway, not /opt/.
+        # See device/docs/PUBLISHING.md for the full post-mortem.
+        if [ -n "${2:-}" ] && dpkg --compare-versions "$2" le-nl 0.2.1 \
+                2>/dev/null; then
+            if [ -f /opt/uconsole/scripts/system/backup.sh ]; then
+                rm -f /opt/uconsole/scripts/system/backup.sh
+                echo "Security: removed leaky backup.sh shipped in $2 (now in" \
+                     "the operator-private ~/pkg/ backup repo only)."
+                echo "  See https://github.com/mikevitelli/uconsole-cloud" \
+                     "release notes for v0.2.2 if you ran it from a git" \
+                     "working tree — rotate WiFi PSKs and GitHub PATs."
+            fi
+        fi
+
         # ── Battery-safety services (UNSTABLE — opt-in) ────────────────
         # Four units ship pointing at /opt/uconsole/scripts/power/ and
         # /opt/uconsole/scripts/util/. They are NOT auto-enabled on

--- a/packaging/private_scripts.txt
+++ b/packaging/private_scripts.txt
@@ -1,0 +1,22 @@
+# Scripts that the TUI menu references but that MUST NOT ship in the .deb.
+# These are device-private (live in the operator's backup repo, not here).
+#
+# Format: one path per line, relative to device/scripts/.
+# Lines starting with `#` and blank lines are comments — ignored by the
+# loaders.
+#
+# Single source of truth — read by:
+#   packaging/build-deb.sh         (scrub + post-build assertion)
+#   tests/test_tui_integrity.py    (skip-list for menu-resolves-to-file test)
+#   tests/test_resolve_cmd.py      (skip-list for command resolution test)
+#
+# Adding a script here = it's allowed to be missing from the public tree.
+# Removing a script = the test will fail until you actually ship it.
+#
+# History: backup.sh was removed in d2f3783 (2026-04-22) after a 2026-04-17
+# incident where it auto-committed five .nmconnection files with plaintext
+# WiFi PSKs to origin/dev. The 0.2.1 .deb (built 2026-04-15) still ships it
+# because the file was in canonical at build time. The post-build assertion
+# in build-deb.sh closes that gap going forward.
+
+system/backup.sh

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -1,0 +1,302 @@
+"""Regression tests for security fixes from the 2026-03-24 audit and the
+2026-05-09 dev-hardening pass.
+
+These are pattern/source-level tests, not behavioral. The intent is a CI
+safety net: if someone reverts a fix, the test fails immediately with a
+named pointer to the audit finding it covers. They certify that the
+mitigation is *present*, not that the mitigation is correct under every
+input — the actual proofs live in the audit docs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _read(rel: str) -> str:
+    with open(os.path.join(REPO, rel), encoding="utf-8") as f:
+        return f.read()
+
+
+# ── 2026-03-24 audit: webdash.py XSS + security headers + SSE POST ────────
+
+
+def test_webdash_security_headers_handler_present():
+    """add_security_headers must set X-Frame-Options, CSP, X-Content-Type-Options,
+    Referrer-Policy. Audit fix; CLAUDE.md "Security Notes" line item."""
+    src = _read("device/webdash/app.py")
+    handler = re.search(
+        r"@app\.after_request\s+def add_security_headers\([^)]*\):.*?return response",
+        src,
+        re.DOTALL,
+    )
+    assert handler, "add_security_headers handler missing"
+    body = handler.group(0)
+    assert "X-Frame-Options" in body, "X-Frame-Options not set"
+    assert "Content-Security-Policy" in body, "CSP not set"
+    assert "X-Content-Type-Options" in body, "X-Content-Type-Options not set"
+    assert "Referrer-Policy" in body, "Referrer-Policy not set"
+
+
+def test_webdash_stream_endpoint_is_post_only():
+    """/api/stream/<script> must be POST. GET state-changing endpoints
+    were the audit's SSE POST-only callout — and a regression in the
+    state of dev pre-2026-05-09."""
+    src = _read("device/webdash/app.py")
+    m = re.search(
+        r"@app\.route\(\s*['\"]/api/stream/<script>['\"]\s*,\s*methods=\[([^]]*)\]",
+        src,
+    )
+    assert m, "/api/stream/<script> route declaration not found"
+    methods = m.group(1)
+    assert "'POST'" in methods or '"POST"' in methods, (
+        "/api/stream must include POST"
+    )
+    assert "'GET'" not in methods and '"GET"' not in methods, (
+        "/api/stream must NOT include GET — audit specified POST-only"
+    )
+
+
+def test_webdash_no_innerHTML_with_user_data_in_dashboard_js():
+    """Dashboard JS must not build click handlers via string concatenation
+    (`onclick="selectWifi(...)"`). Regression of the SSID DOM-XSS fix."""
+    src = _read("device/webdash/static/js/dashboard.js")
+    forbidden = (
+        "onclick=\"selectWifi",
+        "onclick='selectWifi",
+        "onclick=\"connectWifi",
+        "onclick='connectWifi",
+    )
+    for pat in forbidden:
+        assert pat not in src, f"{pat!r} re-introduced — SSID XSS regression"
+
+
+def test_webdash_static_and_template_dashboard_js_in_sync():
+    """Two byte-identical copies of dashboard.js exist; if they drift, an
+    audit fix could land in one and miss the other."""
+    a = _read("device/webdash/static/js/dashboard.js")
+    b = _read("device/webdash/templates/js/dashboard.js")
+    assert a == b, (
+        "static/js/dashboard.js and templates/js/dashboard.js drifted — "
+        "both must be updated in lockstep until consolidated"
+    )
+
+
+# ── 2026-05-09 dev-hardening: X-Real-IP pinning + auth rate limit ──────────
+
+
+def test_webdash_x_real_ip_only_via_client_ip_helper():
+    """Direct `request.headers.get('X-Real-IP', request.remote_addr)` was
+    spoofable by any client. The fix introduces _client_ip() that only
+    honors X-Real-IP from loopback. No other call site may bypass it."""
+    src = _read("device/webdash/app.py")
+    # _client_ip helper is the one allowed reader of X-Real-IP.
+    assert "def _client_ip" in src, "_client_ip helper missing"
+    # Outside that helper, no `request.headers.get('X-Real-IP'...)` direct calls.
+    direct_reads = re.findall(r"request\.headers\.get\(\s*['\"]X-Real-IP['\"]", src)
+    # Exactly one reference is allowed: the one inside _client_ip itself.
+    assert len(direct_reads) == 1, (
+        f"X-Real-IP read in {len(direct_reads)} places — must only be in _client_ip"
+    )
+
+
+def test_webdash_login_path_is_rate_limited():
+    """/login and /api/set-password must be rate-limited per IP. Without it
+    a 4-character password floor was trivially brute-forceable from LAN."""
+    src = _read("device/webdash/app.py")
+    assert "_check_auth_rate_limit" in src, "_check_auth_rate_limit missing"
+    assert "_AUTH_PATHS" in src, "_AUTH_PATHS frozenset missing"
+    assert "_PASSWORD_MIN_LEN" in src, "password min-length constant missing"
+    # Floor must not regress to anything below 8.
+    m = re.search(r"_PASSWORD_MIN_LEN\s*=\s*(\d+)", src)
+    assert m, "_PASSWORD_MIN_LEN value not parseable"
+    assert int(m.group(1)) >= 8, (
+        f"password floor regressed to {m.group(1)} — was raised from 4 to 10"
+    )
+
+
+# ── 2026-03-24 audit: wifi.sh + wifi-fallback.sh lockfile location ─────────
+
+
+def test_wifi_sh_lock_not_in_world_writable_tmp():
+    """wifi.sh lockfile must live in $XDG_RUNTIME_DIR or /run, never /tmp.
+    Audit fix for the world-writable-lock TOCTOU."""
+    src = _read("device/scripts/network/wifi.sh")
+    # Find the LOCK / LOCKFILE assignment.
+    assert "XDG_RUNTIME_DIR" in src or "/run/" in src, (
+        "wifi.sh must use XDG_RUNTIME_DIR or /run for its lock"
+    )
+    # No bare /tmp/ paths used as lockfiles.
+    bad = re.search(r'(?:LOCK[A-Z_]*|lock[a-z_]*)\s*=\s*["\']?/tmp/', src)
+    assert not bad, "wifi.sh has a /tmp lockfile path — audit regression"
+
+
+def test_wifi_fallback_lock_not_in_world_writable_tmp():
+    """wifi-fallback.sh: same lockfile-location requirement."""
+    src = _read("device/scripts/network/wifi-fallback.sh")
+    assert "XDG_RUNTIME_DIR" in src or "/run/" in src, (
+        "wifi-fallback.sh must use XDG_RUNTIME_DIR or /run for its lock"
+    )
+    bad = re.search(r'(?:LOCK[A-Z_]*|lock[a-z_]*)\s*=\s*["\']?/tmp/', src)
+    assert not bad, "wifi-fallback.sh has a /tmp lockfile path — audit regression"
+
+
+# ── 2026-03-24 audit: console.py / TUI argv-form subprocess ────────────────
+
+
+def test_tui_ssh_uses_argv_subprocess():
+    """SSH bookmark launcher must invoke ssh via argv list, not os.system /
+    shell=True / f-string concat. Audit fix for SSH hostname injection."""
+    src = _read("device/lib/tui/tools.py")
+    assert 'subprocess.run(["ssh"' in src, (
+        "ssh bookmark launcher no longer uses subprocess.run with argv list"
+    )
+    # Make sure no ssh f-string snuck in.
+    assert 'os.system(f"ssh' not in src, "ssh shell-injection via f-string"
+    assert 'os.system("ssh' not in src, "ssh via os.system"
+    assert 'subprocess.run(f"ssh' not in src, "ssh via shell-form subprocess"
+
+
+def test_tui_bluetooth_uses_argv_subprocess():
+    """Bluetooth pairing must invoke bluetoothctl via argv list. Audit
+    fix for MAC injection (paired MAC came from bluetoothctl output)."""
+    src = _read("device/lib/tui/network.py")
+    assert 'subprocess.run(["bluetoothctl"' in src, (
+        "bluetooth control no longer uses argv-form subprocess"
+    )
+    assert 'os.system(f"bluetoothctl' not in src
+    assert 'subprocess.run(f"bluetoothctl' not in src
+
+
+def test_tui_process_kill_validates_pid():
+    """The process-killer must validate PID is numeric + within kernel
+    pid_max. Audit fix for kill-arbitrary-string injection."""
+    src = _read("device/lib/tui/processes.py")
+    assert "pid.isdigit()" in src, "PID isdigit check missing"
+    # Range check: 2 <= pid <= 4194304 (typical pid_max). Look for the
+    # presence of the range gate, not the exact literal.
+    range_check = re.search(r"int\(pid\)\s*<=\s*\d{6,7}", src)
+    assert range_check, "PID upper-bound check missing"
+    assert "os.kill(int(pid)" in src, "kill must use os.kill with int conversion"
+
+
+# ── 2026-05-09 dev-hardening: cloud wifi.ip href validation ───────────────
+
+
+def test_cloud_local_dashboard_url_helper_exists():
+    """The cloud must validate device-pushed wifi.ip before interpolating
+    into href. Helper must reject non-IP values."""
+    src = _read("frontend/src/lib/network.ts")
+    assert "buildLocalDashboardUrl" in src, "buildLocalDashboardUrl helper missing"
+    assert "isValidIp" in src, "isValidIp helper missing"
+    # The helper must reject by default (return null on non-IP).
+    assert "return null" in src
+
+
+def test_cloud_local_mode_shell_uses_validator():
+    """LocalModeShell.tsx must build the webdashUrl via the validator,
+    not via raw `https://${...}` interpolation."""
+    src = _read("frontend/src/components/dashboard/LocalModeShell.tsx")
+    assert "buildLocalDashboardUrl" in src, (
+        "LocalModeShell.tsx must call buildLocalDashboardUrl"
+    )
+    # No raw `https://${deviceLocalIp}` interpolation.
+    assert "`https://${deviceLocalIp}`" not in src, (
+        "raw https://${deviceLocalIp} interpolation regression"
+    )
+
+
+def test_cloud_device_online_uses_validator():
+    """DeviceOnline.tsx Local Shell Hub link must go through the validator."""
+    src = _read("frontend/src/components/dashboard/DeviceOnline.tsx")
+    assert "buildLocalDashboardUrl" in src, (
+        "DeviceOnline.tsx must call buildLocalDashboardUrl"
+    )
+    assert "`https://${wifi.ip}`" not in src, (
+        "raw https://${wifi.ip} interpolation regression"
+    )
+
+
+# ── 2026-05-09 dev-hardening: /api/device/push gating ─────────────────────
+
+
+def test_device_push_route_has_rate_limit_and_size_cap():
+    """The push endpoint must have per-token rate limit + body size cap +
+    shape check. Without these, a leaked Bearer token is a DoS."""
+    src = _read("frontend/src/app/api/device/push/route.ts")
+    assert "checkRateLimit" in src, "rate-limit import missing"
+    assert "MAX_BODY_BYTES" in src, "body size cap missing"
+    assert "isValidTelemetry" in src, "shape validator missing"
+    # Status 413 on oversize, 429 on rate limit — present in the file.
+    assert "413" in src, "413 Payload Too Large response missing"
+    assert "429" in src, "429 Too Many Requests response missing"
+
+
+# ── 2026-05-09 dev-hardening: TUI CONFIG_FILE under XDG ──────────────────
+
+
+def test_tui_config_file_under_xdg_config_home():
+    """CONFIG_FILE was under SCRIPT_DIR (root-owned post-deploy) — must
+    now resolve under $XDG_CONFIG_HOME / ~/.config/uconsole/."""
+    src = _read("device/lib/tui/framework.py")
+    assert "XDG_CONFIG_HOME" in src, "XDG_CONFIG_HOME branch missing"
+    assert "_migrate_legacy_config" in src, "legacy migration helper missing"
+    # CONFIG_FILE must NOT be just SCRIPT_DIR + .console-config.json.
+    bad = re.search(
+        r"CONFIG_FILE\s*=\s*os\.path\.join\(\s*SCRIPT_DIR,\s*['\"]\.console-config\.json",
+        src,
+    )
+    assert not bad, "CONFIG_FILE re-pinned to SCRIPT_DIR — regression"
+
+
+# ── 2026-05-09 dev-hardening: restore.sh local-outside-function ──────────
+
+
+def test_restore_sh_no_local_outside_function():
+    """restore.sh runs under `set -e`; `local` outside a function aborts
+    the script mid-run. The fix dropped the bare `local` declarations."""
+    src = _read("device/scripts/system/restore.sh")
+    # Find every `local` occurrence and verify each is inside a function.
+    # Simple heuristic: walk lines, track depth via `name() {` / `}` braces.
+    in_fn = 0
+    bad_lines = []
+    for ln_num, line in enumerate(src.splitlines(), start=1):
+        stripped = line.strip()
+        if re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*\s*\(\s*\)\s*\{", stripped):
+            in_fn += 1
+        elif stripped == "}" and in_fn > 0:
+            in_fn -= 1
+        if re.match(r"^\s*local\b", line) and in_fn == 0:
+            bad_lines.append(ln_num)
+    assert not bad_lines, (
+        f"restore.sh: `local` declared outside any function on lines "
+        f"{bad_lines} — would abort with set -e"
+    )
+
+
+# ── 2026-05-09 dev-hardening: sudoers files removed from source ──────────
+
+
+def test_no_leaked_sudoers_files_in_source():
+    """device/scripts/system/etc/sudoers.d/ must not contain a
+    NOPASSWD: ALL grant or hardcoded operator usernames."""
+    sudoers = os.path.join(REPO, "device/scripts/system/etc/sudoers.d")
+    if not os.path.isdir(sudoers):
+        pytest.skip("sudoers.d directory not present (clean)")
+    for fname in os.listdir(sudoers):
+        path = os.path.join(sudoers, fname)
+        if not os.path.isfile(path):
+            continue
+        with open(path) as f:
+            body = f.read()
+        assert "NOPASSWD: ALL" not in body, (
+            f"{fname}: NOPASSWD: ALL grant must not ship in source"
+        )
+        assert "mikevitelli " not in body, (
+            f"{fname}: hardcoded operator username 'mikevitelli' present"
+        )

--- a/tests/test_resolve_cmd.py
+++ b/tests/test_resolve_cmd.py
@@ -1,7 +1,12 @@
-"""Tests for _resolve_cmd: script path resolution.
+"""Tests for tui.framework._resolve_cmd: script path resolution.
+
+Calls the real production function. The previous version defined a
+hand-copied standalone helper with different search-base semantics
+(included ~/scripts that production does not), so passing tests didn't
+certify the production resolver.
 
 This is the function that broke in production (doubled subdir paths).
-Tests every script reference in menus against actual files.
+Tests every script reference in menus against actual files on disk.
 """
 
 import os
@@ -15,26 +20,10 @@ SCRIPTS_DIR = os.path.join(DEVICE_DIR, 'scripts')
 if LIB_DIR not in sys.path:
     sys.path.insert(0, LIB_DIR)
 
-
-def _resolve_cmd_standalone(script_name, script_dir):
-    """Standalone copy of _resolve_cmd for testing without curses imports."""
-    parts = script_name.split()
-    name = parts[0]
-    bases = []
-    for b in [script_dir, '/opt/uconsole/scripts', os.path.expanduser('~/scripts')]:
-        if os.path.isdir(b) and b not in bases:
-            bases.append(b)
-    for b in bases:
-        path = os.path.join(b, name)
-        if os.path.isfile(path):
-            return path, ["bash", path] + parts[1:]
-    basename = os.path.basename(name)
-    if basename != name:
-        for b in bases:
-            path = os.path.join(b, basename)
-            if os.path.isfile(path):
-                return path, ["bash", path] + parts[1:]
-    return None, None
+# When framework.py imports, _PKG_ROOT resolves to <repo>/device, so
+# SCRIPT_DIR auto-resolves to <repo>/device/scripts — exactly what we
+# want for these tests. No env override needed.
+from tui.framework import _resolve_cmd  # noqa: E402
 
 
 # Scripts the menu references but that aren't shipped in the public tree
@@ -92,13 +81,13 @@ def _extract_all_script_names():
 ALL_SCRIPT_REFS = _extract_all_script_names()
 
 
-class TestResolveCmdWithExampleDevice:
-    """Test _resolve_cmd using SCRIPTS_DIR = device/scripts/."""
+class TestResolveCmd:
+    """Test the real _resolve_cmd against every menu reference."""
 
     @pytest.mark.parametrize("script_ref", ALL_SCRIPT_REFS)
     def test_resolves(self, script_ref):
         """Each menu script reference must resolve to a real file."""
-        path, cmd = _resolve_cmd_standalone(script_ref, SCRIPTS_DIR)
+        path, cmd = _resolve_cmd(script_ref)
         assert path is not None, (
             f"_resolve_cmd failed for '{script_ref}'. "
             f"Expected to find: {os.path.join(SCRIPTS_DIR, script_ref.split()[0])}"
@@ -108,42 +97,35 @@ class TestResolveCmdWithExampleDevice:
     @pytest.mark.parametrize("script_ref", ALL_SCRIPT_REFS)
     def test_cmd_starts_with_bash(self, script_ref):
         """Resolved command must start with 'bash'."""
-        path, cmd = _resolve_cmd_standalone(script_ref, SCRIPTS_DIR)
+        _, cmd = _resolve_cmd(script_ref)
         if cmd is not None:
             assert cmd[0] == "bash"
 
     @pytest.mark.parametrize("script_ref", ALL_SCRIPT_REFS)
     def test_preserves_args(self, script_ref):
         """Script arguments must be preserved in the resolved command."""
-        path, cmd = _resolve_cmd_standalone(script_ref, SCRIPTS_DIR)
+        _, cmd = _resolve_cmd(script_ref)
         parts = script_ref.split()
         if cmd is not None and len(parts) > 1:
-            assert cmd[2:] == parts[1:], f"Args mismatch: expected {parts[1:]}, got {cmd[2:]}"
+            assert cmd[2:] == parts[1:], (
+                f"Args mismatch: expected {parts[1:]}, got {cmd[2:]}"
+            )
 
 
 class TestResolveCmdEdgeCases:
     def test_nonexistent_script(self):
-        path, cmd = _resolve_cmd_standalone("nonexistent/fake.sh", SCRIPTS_DIR)
+        path, cmd = _resolve_cmd("nonexistent/fake.sh")
         assert path is None
         assert cmd is None
 
     def test_script_with_args(self):
         """Scripts with args like 'system/update.sh all' should resolve."""
-        path, cmd = _resolve_cmd_standalone("system/update.sh all", SCRIPTS_DIR)
+        path, cmd = _resolve_cmd("system/update.sh all")
         if path:
             assert cmd[-1] == "all"
 
     def test_no_double_subdir(self):
         """Must NOT create paths like scripts/util/util/script.sh."""
-        path, cmd = _resolve_cmd_standalone("util/webdash-info.sh", SCRIPTS_DIR)
+        path, _ = _resolve_cmd("util/webdash-info.sh")
         if path:
             assert "util/util/" not in path, f"Doubled subdir in path: {path}"
-            assert "util\\util\\" not in path
-
-    def test_fallback_to_basename(self):
-        """If subdir/script.sh not found, try just script.sh in base dirs."""
-        # Create a scenario where this matters: nonexistent subdir
-        path, cmd = _resolve_cmd_standalone("fakedir/battery.sh", SCRIPTS_DIR)
-        # Should try basename fallback: look for battery.sh in base dirs
-        # May or may not find it depending on layout, but should not crash
-        # The key assertion is no exception

--- a/tests/test_resolve_cmd.py
+++ b/tests/test_resolve_cmd.py
@@ -39,9 +39,19 @@ def _resolve_cmd_standalone(script_name, script_dir):
 
 # Scripts the menu references but that aren't shipped in the public tree
 # (private repos provide them at install time — see test_tui_integrity.py).
-KNOWN_PRIVATE_SCRIPTS = {
-    "system/backup.sh",   # removed from public tree in d2f3783 for security
-}
+# Single source of truth: packaging/private_scripts.txt — also consumed by
+# packaging/build-deb.sh.
+def _load_private_scripts():
+    path = os.path.join(os.path.dirname(__file__), '..', 'packaging', 'private_scripts.txt')
+    out = set()
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                out.add(line)
+    return out
+
+KNOWN_PRIVATE_SCRIPTS = _load_private_scripts()
 
 
 def _extract_all_script_names():

--- a/tests/test_run_and_capture.py
+++ b/tests/test_run_and_capture.py
@@ -1,10 +1,14 @@
-"""Tests for _run_and_capture: subprocess execution and output processing."""
+"""Tests for tui.framework._run_and_capture: subprocess execution and
+output processing.
+
+Calls the real production function — the previous version of this test
+defined a hand-copied standalone helper that drifted from the real
+implementation (different timeout string, missing "(no output)" /
+"(error: ...)" branches), so passing tests didn't certify production.
+"""
 
 import os
 import sys
-import subprocess
-from unittest.mock import patch, MagicMock
-
 import pytest
 
 DEVICE_DIR = os.path.join(os.path.dirname(__file__), '..', 'device')
@@ -12,83 +16,76 @@ LIB_DIR = os.path.join(DEVICE_DIR, 'lib')
 if LIB_DIR not in sys.path:
     sys.path.insert(0, LIB_DIR)
 
-
-def _run_and_capture(cmd, timeout=30):
-    """Standalone copy matching framework.py implementation."""
-    import re
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-        combined = result.stdout + result.stderr
-        lines = combined.strip().split('\n')
-        lines = [re.sub(r'\x1b\[[0-9;]*[A-Za-z]', '', line) for line in lines]
-        max_width = max((len(line) for line in lines), default=0)
-        return (lines, result.returncode, max_width)
-    except subprocess.TimeoutExpired:
-        return (["TIMEOUT after {} seconds".format(timeout)], 1, 30)
+from tui.framework import _run_and_capture  # noqa: E402
 
 
 class TestRunAndCapture:
     def test_simple_command(self):
-        lines, retcode, width = _run_and_capture(["echo", "hello world"])
+        lines, retcode, _ = _run_and_capture(["echo", "hello world"])
         assert retcode == 0
         assert "hello world" in lines
 
     def test_multiline_output(self):
-        lines, retcode, width = _run_and_capture(["printf", "line1\nline2\nline3"])
+        lines, retcode, _ = _run_and_capture(["printf", "line1\nline2\nline3"])
         assert retcode == 0
-        assert len(lines) == 3
-        assert lines[0] == "line1"
-        assert lines[2] == "line3"
+        assert "line1" in lines
+        assert "line2" in lines
+        assert "line3" in lines
 
     def test_strips_ansi_codes(self):
-        # echo with ANSI color codes
-        lines, retcode, width = _run_and_capture(
+        lines, retcode, _ = _run_and_capture(
             ["printf", "\x1b[32mgreen\x1b[0m \x1b[1mbold\x1b[0m"]
         )
         assert retcode == 0
-        assert lines[0] == "green bold"
+        # Production strips ANSI then splitlines — colorless text remains.
+        assert any("green" in l and "bold" in l for l in lines)
+        assert not any("\x1b" in l for l in lines)
 
     def test_strips_complex_ansi(self):
         lines, _, _ = _run_and_capture(
             ["printf", "\x1b[38;5;196mred256\x1b[0m"]
         )
-        assert "red256" in lines[0]
-        assert "\x1b" not in lines[0]
+        assert any("red256" in l for l in lines)
+        assert not any("\x1b" in l for l in lines)
 
     def test_nonzero_exit_code(self):
-        lines, retcode, width = _run_and_capture(["bash", "-c", "exit 42"])
+        _, retcode, _ = _run_and_capture(["bash", "-c", "exit 42"])
         assert retcode == 42
 
     def test_stderr_captured(self):
-        lines, retcode, width = _run_and_capture(
+        lines, _, _ = _run_and_capture(
             ["bash", "-c", "echo stdout; echo stderr >&2"]
         )
         assert any("stdout" in l for l in lines)
         assert any("stderr" in l for l in lines)
 
-    def test_timeout(self):
-        lines, retcode, width = _run_and_capture(
-            ["sleep", "10"], timeout=1
-        )
+    def test_timeout_returns_sentinel_string(self):
+        """Production hard-codes the literal '(timed out after 30s)' even
+        when timeout differs (a separate bug already noted). The test
+        documents that production behavior so regressions surface."""
+        lines, retcode, _ = _run_and_capture(["sleep", "10"], timeout=1)
         assert retcode == 1
-        assert "TIMEOUT" in lines[0]
+        assert any("timed out" in l.lower() for l in lines)
 
-    def test_empty_output(self):
-        lines, retcode, width = _run_and_capture(["true"])
+    def test_empty_output_returns_no_output_sentinel(self):
+        """Production replaces blank output with '(no output)'."""
+        lines, retcode, _ = _run_and_capture(["true"])
         assert retcode == 0
-        # Empty output gives [''] after strip().split('\n')
-        assert isinstance(lines, list)
+        assert any("no output" in l for l in lines)
 
     def test_max_width_calculation(self):
-        lines, retcode, width = _run_and_capture(
+        lines, _, width = _run_and_capture(
             ["printf", "short\nthis is a longer line\nmed"]
         )
-        assert width == len("this is a longer line")
+        assert width == max(len(l) for l in lines)
+        assert width >= len("this is a longer line")
 
-    def test_binary_in_path(self):
-        """Should handle scripts that don't exist gracefully."""
-        with pytest.raises(FileNotFoundError):
-            _run_and_capture(["/nonexistent/script.sh"])
+    def test_missing_binary_returns_error_sentinel(self):
+        """Production catches Exception (FileNotFoundError) and returns
+        an '(error: ...)' line — does not raise."""
+        lines, retcode, _ = _run_and_capture(["/nonexistent/script.sh"])
+        assert retcode == 1
+        assert any("error" in l.lower() for l in lines)
 
 
 class TestRunAndCaptureWithRealScripts:
@@ -108,5 +105,5 @@ class TestRunAndCaptureWithRealScripts:
         path = self._script_path(script)
         if not os.path.isfile(path):
             pytest.skip(f"Script not found: {path}")
-        lines, retcode, _ = _run_and_capture(["bash", "-n", path])
-        assert retcode == 0, f"Syntax error in {script}: {lines}"
+        _, retcode, _ = _run_and_capture(["bash", "-n", path])
+        assert retcode == 0, f"Syntax error in {script}"

--- a/tests/test_tui_integrity.py
+++ b/tests/test_tui_integrity.py
@@ -351,10 +351,20 @@ class TestSubmenuIntegrity:
 # /opt/uconsole/scripts/ at install time, so the menu reference is correct
 # from a runtime perspective. The test must skip them so CI doesn't false-
 # fail on the absence.
-KNOWN_PRIVATE_SCRIPTS = {
-    "system/backup.sh",   # removed from public tree in d2f3783 for security;
-                          # users get it via their own backup repos
-}
+#
+# Single source of truth: packaging/private_scripts.txt — also consumed by
+# packaging/build-deb.sh to scrub + post-build assert.
+def _load_private_scripts():
+    path = os.path.join(os.path.dirname(__file__), '..', 'packaging', 'private_scripts.txt')
+    out = set()
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                out.add(line)
+    return out
+
+KNOWN_PRIVATE_SCRIPTS = _load_private_scripts()
 
 
 class TestScriptPaths:


### PR DESCRIPTION
## Summary

Lands the hardening backlog onto `dev` ahead of the next release. Combines (a) three commits already on `claude/build-pipeline-hardening-2026-05-05` that hadn't been merged forward, (b) the seven user-accepted findings from the multi-agent review of `dev`, and (c) a CI safety net for both the 2026-03-24 audit fixes and this hardening pass.

13 commits, ~1000 insertions / ~225 deletions. Built and tested clean.

## Cherry-picks (regressions on dev)

- `096b696` — post-build assertion against private-script leak in .deb (was `7d1d514`)
- `a85074f` — Debian Policy 12.5/12.7 compliance: ship `changelog` + `copyright` (was `af4dd69`)
- `981b1a6` — postinst removes leaky `backup.sh` on upgrade from 0.1.0–0.2.1 (was `f5ed838`)

The Makefile portion of `af4dd69` was dropped during cherry-pick: it removed two `LINTIAN_SUPPRESS` entries inside a `test-deb-lintian` target that doesn't exist on `dev` (added by `780597e`, intentionally not in this PR).

## Hardening fixes (accepted from review)

| Severity | Area | Fix |
|---|---|---|
| HIGH | `device/scripts/system/etc/sudoers.d/` | Deleted leaked `010_pi-nopasswd` (`NOPASSWD: ALL`) and `hwclock` files — both hardcoded operator username |
| HIGH | `device/scripts/system/restore.sh` | Dropped `local` declarations outside any function; under `set -e` they'd abort restore mid-run |
| HIGH | `device/lib/tui/framework.py` | `CONFIG_FILE` moved from `SCRIPT_DIR/.console-config.json` (root-owned post-deploy) to `$XDG_CONFIG_HOME/uconsole/console.json`; one-shot legacy migration |
| HIGH | `device/webdash/static+templates/js/dashboard.js` | WiFi modal SSID DOM-XSS killed — replaced `onclick=""` string-concat with `addEventListener` + `textContent`. Both byte-identical copies updated in lockstep |
| HIGH | `device/webdash/app.py` | `/api/stream/<script>` now POST-only (was GET, audit fix had regressed); JS client switched from `EventSource` to `fetch()` streaming |
| HIGH | `device/webdash/app.py` | `X-Real-IP` only honored from loopback `remote_addr` via new `_client_ip()` helper — closes the spoofing path that unlocked `_LOCAL_ONLY_PATHS` |
| HIGH | `device/webdash/app.py` | `/login` + `/api/set-password` now per-IP rate-limited (10/60s) on top of the `_PUBLIC_PATHS` bypass; password floor raised from 4 → 10 chars |
| HIGH | `frontend/src/components/dashboard/{LocalModeShell,DeviceOnline,QuickActions}.tsx` | Device-pushed `wifi.ip` validated as literal IPv4/IPv6 before `https://${...}` interpolation; helper at `lib/network.ts` (`isValidIp`, `buildLocalDashboardUrl`) |
| HIGH | `frontend/src/app/api/device/push/route.ts` | Added per-token rate limit (30/60s), 32 KB body cap (Content-Length pre-check + JSON.stringify post-check), shape validation on `hostname` + `collectedAt` |
| MED | `.github/workflows/ci.yml`, `release.yml` | All third-party actions pinned by full commit SHA; ci.yml top-level `permissions: contents: read` |

Battery-safety items (raw I2C register write, low-battery-shutdown threshold drift) were explicitly **not** in scope for this PR — they need a hardware-eyes-on review.

## Tests

- New `tests/test_audit_regressions.py` (18 tests, ~60 ms) — pattern-level CI safety net for both the 2026-03-24 audit fixes (security headers, SSE method, wifi.sh lock path, TUI argv-form subprocess, PID validation) and the 2026-05-09 changes here (`_client_ip`, auth rate-limit, password floor, `buildLocalDashboardUrl`, `/api/device/push` controls, XDG config path, sudoers leak guard, `restore.sh` `local`-outside-fn).
- `tests/test_run_and_capture.py` and `tests/test_resolve_cmd.py` rewritten to import the real `tui.framework` functions instead of testing hand-copied standalone copies that had drifted from production.

## Verification

- pytest: **1142 passed, 8 skipped** (14.13 s)
- frontend vitest: **212 passed** (10 files, 2.93 s)
- `tsc --noEmit`: clean
- `eslint`: clean
- `bash -n` on touched scripts: clean
- `python -m py_compile` on touched modules: clean

## Test plan

- [ ] Verify webdash login still works on a real device after the rate-limit and password-length floor changes (use a 10+ char password).
- [ ] Verify `/api/stream` SSE rendering still works in `dashboard.js` (the JS path replaced `EventSource` with `fetch` streaming).
- [ ] Run `make test-device` on a clean checkout to confirm pytest passes.
- [ ] Run `bash packaging/build-deb.sh` and confirm `dpkg -c` shows `/usr/share/doc/uconsole-cloud/{changelog.gz,copyright}` and no private scripts.
- [ ] On a device upgrading from 0.1.x/0.2.x, confirm `~/.config/uconsole/console.json` gets created from the legacy `SCRIPT_DIR/.console-config.json` on first launch.
- [ ] Confirm GHA `release.yml` still publishes via the SHA-pinned `softprops/action-gh-release` on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)